### PR TITLE
Nico Shanstrom

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ group :development, :test do
   gem 'pry'
   gem 'simplecov'
   gem 'shoulda-matchers'
+  gem "orderly"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,9 @@ GEM
       racc (~> 1.4)
     nokogiri (1.15.2-x86_64-darwin)
       racc (~> 1.4)
+    orderly (0.1.1)
+      capybara (>= 1.1)
+      rspec (>= 2.14)
     pg (1.5.3)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -198,6 +201,10 @@ GEM
     regexp_parser (2.8.0)
     reline (0.3.5)
       io-console (~> 0.5)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.3)
@@ -252,6 +259,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-darwin-21
 
 DEPENDENCIES
@@ -261,6 +269,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   launchy
+  orderly
   pg (~> 1.1)
   pry
   puma (~> 6.0)

--- a/app/controllers/experiments_controller.rb
+++ b/app/controllers/experiments_controller.rb
@@ -1,0 +1,5 @@
+class ExperimentsController < ApplicationController
+  def index
+    @experiments = Experiment.all
+  end
+end

--- a/app/controllers/scientist_experiements_controller.rb
+++ b/app/controllers/scientist_experiements_controller.rb
@@ -1,0 +1,9 @@
+class ScientistExperiementsController < ApplicationController
+  def destroy
+    @scientist = Scientist.find(params[:scientist_id])
+    @experiment = @scientist.experiments.find(params[:id])
+    @experiment.destroy
+    redirect_to scientist_path(@scientist)
+    # require 'pry'; binding.pry
+  end
+end

--- a/app/controllers/scientist_experiements_controller.rb
+++ b/app/controllers/scientist_experiements_controller.rb
@@ -2,7 +2,7 @@ class ScientistExperiementsController < ApplicationController
   def destroy
     @scientist = Scientist.find(params[:scientist_id])
     @experiment = @scientist.experiments.find(params[:id])
-    @experiment.destroy
+    @scientist.experiments.delete(@experiment)
     redirect_to scientist_path(@scientist)
     # require 'pry'; binding.pry
   end

--- a/app/controllers/scientists_controller.rb
+++ b/app/controllers/scientists_controller.rb
@@ -1,0 +1,5 @@
+class ScientistsController < ApplicationController
+  def show
+    @scientist = Scientist.find(params[:id])
+  end
+end

--- a/app/models/experiment.rb
+++ b/app/models/experiment.rb
@@ -1,4 +1,4 @@
 class Experiment < ApplicationRecord
-has_many :scientist_experiements
+has_many :scientist_experiements, dependent: :destroy
 has_many :scientists, through: :scientist_experiements
 end

--- a/app/models/experiment.rb
+++ b/app/models/experiment.rb
@@ -1,0 +1,4 @@
+class Experiment < ApplicationRecord
+has_many :scientist_experiements
+has_many :scientists, through: :scientist_experiements
+end

--- a/app/models/experiment.rb
+++ b/app/models/experiment.rb
@@ -1,4 +1,8 @@
 class Experiment < ApplicationRecord
 has_many :scientist_experiements, dependent: :destroy
 has_many :scientists, through: :scientist_experiements
+
+  def self.desc_order_by_num_months
+    where("num_months >= 6").order("num_months DESC").group(:id)
+  end
 end

--- a/app/models/experiment.rb
+++ b/app/models/experiment.rb
@@ -3,6 +3,6 @@ has_many :scientist_experiements, dependent: :destroy
 has_many :scientists, through: :scientist_experiements
 
   def self.desc_order_by_num_months
-    where("num_months >= 6").order("num_months DESC").group(:id)
+    where("num_months >= 6").order("num_months DESC")
   end
 end

--- a/app/models/lab.rb
+++ b/app/models/lab.rb
@@ -1,3 +1,4 @@
 class Lab < ApplicationRecord
   has_many :scientists
+  has_many :experiments, through: :scientist_experiements
 end

--- a/app/models/lab.rb
+++ b/app/models/lab.rb
@@ -1,4 +1,4 @@
 class Lab < ApplicationRecord
   has_many :scientists
-  has_many :experiments, through: :scientist_experiements
+  # has_many :experiments, through: :scientist_experiements
 end

--- a/app/models/scientist.rb
+++ b/app/models/scientist.rb
@@ -1,3 +1,5 @@
 class Scientist < ApplicationRecord
   belongs_to :lab
+  has_many :scientist_experiements
+  has_many :experiments, through: :scientist_experiements
 end

--- a/app/models/scientist_experiement.rb
+++ b/app/models/scientist_experiement.rb
@@ -1,0 +1,4 @@
+class ScientistExperiement < ApplicationRecord
+belongs_to :scientist
+belongs_to :experiment
+end

--- a/app/views/experiments/index.html.erb
+++ b/app/views/experiments/index.html.erb
@@ -1,0 +1,7 @@
+<h1>All Experients worked on longer than 6 momths</h1>
+
+<% @experiments.desc_order_by_num_months.each do |experiment| %>
+    <li>
+      <h3>Experiment name: <%=experiment.name%></h3>
+    </li>
+<%end%>

--- a/app/views/scientists/show.html.erb
+++ b/app/views/scientists/show.html.erb
@@ -1,0 +1,12 @@
+<h1>Scientist <%=@scientist.name%></h1>
+<h3>Specialty: <%= @scientist.specialty%></h3>
+<h3>University: <%= @scientist.university%></h3>
+<h3>Lab working at: <%= @scientist.lab.name%></h3>
+<h3>Experiments working on</h3>
+<div class="experiments">
+  <% @scientist.experiments.each do |experiment| %>
+    <li>
+      <h3>Experiment: <%=experiment.name%></h3>
+    </li>
+  <%end%>
+</div>

--- a/app/views/scientists/show.html.erb
+++ b/app/views/scientists/show.html.erb
@@ -7,6 +7,7 @@
   <% @scientist.experiments.each do |experiment| %>
     <li>
       <h3>Experiment: <%=experiment.name%></h3>
+      <%= button_to "Delete #{experiment.name}", scientist_experiment_path(@scientist, experiment), method: :delete, data: { turbo: false } %>
     </li>
   <%end%>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "articles#index"
+  resources :scientists, only: [:show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,6 @@ Rails.application.routes.draw do
   resources :scientists, only: [:show] do
     resources :experiments, only: [:destroy], controller: 'scientist_experiements'
   end
+
+  resources :experiments, only: [:index]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,7 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "articles#index"
-  resources :scientists, only: [:show]
+  resources :scientists, only: [:show] do
+    resources :experiments, only: [:destroy], controller: 'scientist_experiements'
+  end
 end

--- a/db/migrate/20240422150813_create_experiments.rb
+++ b/db/migrate/20240422150813_create_experiments.rb
@@ -1,0 +1,11 @@
+class CreateExperiments < ActiveRecord::Migration[7.1]
+  def change
+    create_table :experiments do |t|
+      t.string :name
+      t.string :objective
+      t.integer :num_months
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240422151222_create_scientist_experiements.rb
+++ b/db/migrate/20240422151222_create_scientist_experiements.rb
@@ -1,0 +1,10 @@
+class CreateScientistExperiements < ActiveRecord::Migration[7.1]
+  def change
+    create_table :scientist_experiements do |t|
+      t.references :scientist, null: false, foreign_key: true
+      t.references :experiment, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,31 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_08_014930) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_22_151222) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "experiments", force: :cascade do |t|
+    t.string "name"
+    t.string "objective"
+    t.integer "num_months"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "labs", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "scientist_experiements", force: :cascade do |t|
+    t.bigint "scientist_id", null: false
+    t.bigint "experiment_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["experiment_id"], name: "index_scientist_experiements_on_experiment_id"
+    t.index ["scientist_id"], name: "index_scientist_experiements_on_scientist_id"
   end
 
   create_table "scientists", force: :cascade do |t|
@@ -30,5 +47,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_08_014930) do
     t.index ["lab_id"], name: "index_scientists_on_lab_id"
   end
 
+  add_foreign_key "scientist_experiements", "experiments"
+  add_foreign_key "scientist_experiements", "scientists"
   add_foreign_key "scientists", "labs"
 end

--- a/spec/features/experiments/index_spec.rb
+++ b/spec/features/experiments/index_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe "Experiments index page" do
+  describe 'US3' do
+    it 'Displays all experiments longer than 6 months in descending num_months length' do
+      lab = Lab.create!(name: 'Science Lab')
+      scientist1 = lab.scientists.create!(name: 'Nico', specialty: 'Science', university: 'Hard knocks')
+      experiment1 = Experiment.create!(name: 'Something weird', objective: 'Create wierdness', num_months: 9)
+      experiment2 = Experiment.create!(name: 'Something very weird', objective: 'Create super wierdness', num_months: 3)
+      experiment3 = Experiment.create!(name: 'A little too weird', objective: 'Take some weird out', num_months: 11)
+      experiment4 = Experiment.create!(name: 'Cannot stop weird', objective: 'Just let the weird happen', num_months: 15)
+      # When I visit the experiment index page
+      visit experiments_path
+      # I see the names of all long running experiments (longer than 6 months),
+      # And I see the names are in descending order (longest to shortest)
+      expect(experiment4.name).to appear_before(experiment3.name)
+      expect(experiment3.name).to appear_before(experiment1.name)
+      expect(page).to_not have_content(experiment2.name)
+    end
+  end
+end

--- a/spec/features/scientists/show_spec.rb
+++ b/spec/features/scientists/show_spec.rb
@@ -29,4 +29,45 @@ RSpec.describe "Scientist show page" do
       end
     end
   end
+
+  describe 'US 2' do
+    it 'Can remove an experiment from a scientist' do
+      lab = Lab.create!(name: 'Science Lab')
+      
+      scientist1 = lab.scientists.create!(name: 'Nico', specialty: 'Science', university: 'Hard knocks')
+      scientist2 = lab.scientists.create!(name: 'Wolf', specialty: 'Baby science', university: 'Momma and Dadda')
+      
+      experiment1 = Experiment.create!(name: 'Something weird', objective: 'Create wierdness', num_months: 9)
+      experiment2 = Experiment.create!(name: 'Something very weird', objective: 'Create super wierdness', num_months: 3)
+      
+      scientist1_experiment1 = ScientistExperiement.create!(scientist_id: scientist1.id, experiment_id: experiment1.id)
+      scientist1_experiment2 = ScientistExperiement.create!(scientist_id: scientist1.id, experiment_id: experiment2.id)
+      scientist2_experiment1 = ScientistExperiement.create!(scientist_id: scientist2.id, experiment_id: experiment1.id)
+      # As a visitor
+      # When I visit a scientist's show page
+      visit scientist_path(scientist1)
+      within '.experiments' do
+        # Then next to each experiment's name, I see a button to remove that experiment from that scientist's work load
+        expect(page).to have_button("Delete #{experiment1.name}")
+        expect(page).to have_button("Delete #{experiment2.name}")
+        # When I click that button for one experiment
+        click_button("Delete #{experiment1.name}")
+      end
+      # I'm brought back to the scientist's show page
+      expect(current_path).to eq(scientist_path(scientist1))
+      # And I no longer see that experiment's name listed
+      within '.experiments' do
+        # Then next to each experiment's name, I see a button to remove that experiment from that scientist's work load
+        expect(page).to_not have_button("Delete #{experiment1.name}")
+        expect(page).to have_button("Delete #{experiment2.name}")
+        # When I click that button for one experiment
+      end
+      # And when I visit a different scientist's show page that is working on that same experiment,
+      visit scientist_path(scientist2)
+      # Then I see that the experiment is still on the other scientist's work load
+      within '.experiments' do
+        expect(page).to_not have_button("Delete #{experiment1.name}")
+      end
+    end
+  end
 end

--- a/spec/features/scientists/show_spec.rb
+++ b/spec/features/scientists/show_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe "Scientist show page" do
+  describe 'US1' do
+    it 'Displays all scientists information: name, speciality, university' do
+      lab = Lab.create!(name: 'Science Lab')
+      scientist1 = lab.scientists.create!(name: 'Nico', specialty: 'Science', university: 'Hard knocks')
+      experiment1 = Experiment.create!(name: 'Something weird', objective: 'Create wierdness', num_months: 9)
+      experiment2 = Experiment.create!(name: 'Something very weird', objective: 'Create super wierdness', num_months: 3)
+      scientist1_experiment1 = ScientistExperiement.create!(scientist_id: scientist1.id, experiment_id: experiment1.id)
+      scientist1_experiment2 = ScientistExperiement.create!(scientist_id: scientist1.id, experiment_id: experiment2.id)
+      # require 'pry'; binding.pry
+      # As a visitor
+      # When I visit a scientist's show page
+      visit scientist_path(scientist1)
+      # I see all of that scientist's information including:
+      #  - name
+      expect(page).to have_content("Scientist #{scientist1.name}")
+      #  - specialty
+      expect(page).to have_content("Specialty: #{scientist1.specialty}")
+      #  - university where they got their degree
+      expect(page).to have_content("University: #{scientist1.university}")
+      # And I see the name of the lab where this scientist works
+      expect(page).to have_content("Lab working at: #{scientist1.lab.name}")
+      # And I see the names of all of the experiments this scientist is running
+      within '.experiments' do
+        expect(page).to have_content("Experiment: #{scientist1.experiments.first.name}")
+        expect(page).to have_content("Experiment: #{scientist1.experiments.second.name}")
+      end
+    end
+  end
+end

--- a/spec/features/scientists/show_spec.rb
+++ b/spec/features/scientists/show_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe "Scientist show page" do
       expect(page).to have_content("Lab working at: #{scientist1.lab.name}")
       # And I see the names of all of the experiments this scientist is running
       within '.experiments' do
-        expect(page).to have_content("Experiment: #{scientist1.experiments.first.name}")
-        expect(page).to have_content("Experiment: #{scientist1.experiments.second.name}")
+        expect(page).to have_content("Experiment: #{experiment1.name}")
+        expect(page).to have_content("Experiment: #{experiment2.name}")
       end
     end
   end
@@ -58,7 +58,7 @@ RSpec.describe "Scientist show page" do
       # And I no longer see that experiment's name listed
       within '.experiments' do
         # Then next to each experiment's name, I see a button to remove that experiment from that scientist's work load
-        expect(page).to_not have_button("Delete #{experiment1.name}")
+        expect(page).to_not have_content(experiment1.name)
         expect(page).to have_button("Delete #{experiment2.name}")
         # When I click that button for one experiment
       end
@@ -66,7 +66,8 @@ RSpec.describe "Scientist show page" do
       visit scientist_path(scientist2)
       # Then I see that the experiment is still on the other scientist's work load
       within '.experiments' do
-        expect(page).to_not have_button("Delete #{experiment1.name}")
+        expect(page).to have_content(experiment1.name)
+        save_and_open_page
       end
     end
   end

--- a/spec/models/experiment_spec.rb
+++ b/spec/models/experiment_spec.rb
@@ -4,3 +4,25 @@ RSpec.describe Experiment do
   it {should have_many(:scientist_experiements)}
   it {should have_many(:scientists).through(:scientist_experiements)}
 end
+
+describe '.class methods' do
+  describe 'self.desc_order_by_num_months' do
+    it 'selects only experiments >= 6 months long and orders by descending month length' do
+      lab = Lab.create!(name: 'Science Lab')
+      scientist1 = lab.scientists.create!(name: 'Nico', specialty: 'Science', university: 'Hard knocks')
+      experiment1 = Experiment.create!(name: 'Something weird', objective: 'Create wierdness', num_months: 9)
+      experiment2 = Experiment.create!(name: 'Something very weird', objective: 'Create super wierdness', num_months: 3)
+      experiment3 = Experiment.create!(name: 'A little too weird', objective: 'Take some weird out', num_months: 11)
+      experiment4 = Experiment.create!(name: 'Cannot stop weird', objective: 'Just let the weird happen', num_months: 15)
+      experiments = Experiment.all.desc_order_by_num_months
+      # require 'pry'; binding.pry
+
+      expect(experiments).to include(experiment1)
+      expect(experiments).to include(experiment3)
+      expect(experiments).to include(experiment4)
+
+      expect(experiments.first.num_months).to be >= 6
+      expect(experiments.order("num_months DESC").to_a).to eq(experiments)
+    end
+  end
+end

--- a/spec/models/experiment_spec.rb
+++ b/spec/models/experiment_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Experiment do
+  it {should have_many(:scientist_experiements)}
+  it {should have_many(:scientists).through(:scientist_experiements)}
+end

--- a/spec/models/experiment_spec.rb
+++ b/spec/models/experiment_spec.rb
@@ -23,6 +23,7 @@ describe '.class methods' do
 
       expect(experiments.first.num_months).to be >= 6
       expect(experiments.order("num_months DESC").to_a).to eq(experiments)
+      # require 'pry'; binding.pry
     end
   end
 end

--- a/spec/models/lab_spec.rb
+++ b/spec/models/lab_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Lab do
-  it {should have_many :scientists}
+  it {should have_many(:scientists)}
+  # it {should have_many(:experiments).through(:scientists)}
 end

--- a/spec/models/scientist_experiement_spec.rb
+++ b/spec/models/scientist_experiement_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe ScientistExperiement do
+  it {should belong_to(:scientist)}
+  it {should belong_to(:experiment)}
+end

--- a/spec/models/scientist_spec.rb
+++ b/spec/models/scientist_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Scientist do
-  it {should belong_to :lab}
+  it {should belong_to(:lab)}
+  it {should have_many(:scientist_experiements)}
+  it {should have_many(:experiments).through(:scientist_experiements)}
 end


### PR DESCRIPTION
spelling error on the join table ScientistExperiements really did me dirty in the beginning. I just kept it that way and modified the models and relationships to work with that. SOOOO yeah theres that. I would have had a lot more time to play with the rest of the IC and not finish right before 2 if that didnt happen. 
I think i could have used a command like pluck or something at the end of the self.desc_order_by_num_months method to just pluck name but i did it with it returning the whole object and then i was calling name on that object in the view. 
It was a little weird to figure out how to test that in the model test because it was returning objects in an active record relation, the error was looking something like an array so i added a .to_a on the model test and it works. I could have saved some headache with this and just captured the name in the method then i could have just expected the array in the order expected. All good. Weird is good to see something different. 